### PR TITLE
Only set color to #808080 if it hasn't already been set

### DIFF
--- a/src/farbtastic.js
+++ b/src/farbtastic.js
@@ -510,7 +510,7 @@ $._farbtastic = function (container, options) {
     fb.linkTo(options.callback);
   }
   // Set to gray.
-  fb.setColor('#808080');
+  if (!fb.color) fb.setColor('#808080');
 }
 
 })(jQuery);


### PR DESCRIPTION
Hi there

I ran into this problem where it would always start at #808080 regardless of what the linked field (callback) was set to.

//Lars
