### PR TITLE
Debug mode false by default

### DIFF
--- a/src/farbtastic.js
+++ b/src/farbtastic.js
@@ -1,7 +1,7 @@
 // Farbtastic 2.0 alpha
 (function ($) {
   
-var __debug = true;
+var __debug = false;
 
 $.fn.farbtastic = function (options) {
   $.farbtastic(this, options);


### PR DESCRIPTION
In most use cases there is no need to see the debug messages like

```
drawCircle 3ms
drawMask 2ms
```

underneath the colorpicker.

thanks,
