### PR TITLE
Trigger "change" event after changing this.value = fb.color

### DIFF
--- a/farbtastic.js
+++ b/farbtastic.js
@@ -6,6 +6,8 @@
  */
 (function($) {
 
+var triggerChangeDelay = 200;
+
 $.fn.farbtastic = function (options) {
   $.farbtastic(this, options);
   return this;
@@ -190,7 +192,14 @@ $._farbtastic = function (container, callback) {
       // Change linked value
       $(fb.callback).each(function() {
         if (this.value && this.value != fb.color) {
+          var element = $(this);
           this.value = fb.color;
+          if(fb.triggerChange) {
+            clearInterval(fb.triggerChange);
+          }
+          fb.triggerChange = setTimeout(function() {
+            element.trigger("change");
+          }, triggerChangeDelay);
         }
       });
     }


### PR DESCRIPTION
Farbtastic updates input element value with the chosen color (when using an element as the callback). Although, it's not possible right now to be acknowledged when those changes happen.

This commit triggers the native change event after the color is set. So, user can bind the native "change" event as he would normally do and be notified when a new color is set.
## 

PS: Added a delay mechanism to avoid triggering a bunch of events while sliding the colors.
