### PR TITLE
Fixed missing Explorer Canvas on IE10

### DIFF
--- a/src/farbtastic.js
+++ b/src/farbtastic.js
@@ -98,7 +98,7 @@ $._farbtastic = function (container, options) {
       .find('div>*').css('position', 'absolute');
 
     // IE Fix: Recreate canvas elements with doc.createElement and excanvas.
-    $.browser.msie && $('canvas', container).each(function () {
+    typeof G_vmlCanvasManager != 'undefined' && $.browser.msie && $('canvas', container).each(function () {
       // Fetch info.
       var attr = { 'class': $(this).attr('class'), style: this.getAttribute('style') },
           e = document.createElement('canvas');


### PR DESCRIPTION
Farbtastic didn't work with newer IEs, since it depends on ExCanvas that is obsolete in newer versions and shouldn't be included. Changed the code so that ExCanvas fix is run only when ExCanvas is available.
