### PR TITLE
Missing 'width' option check

### DIFF
--- a/src/farbtastic.js
+++ b/src/farbtastic.js
@@ -490,7 +490,7 @@ $._farbtastic = function (container, options) {
   };
 
   // Parse options.
-  if (!options.callback) {
+  if (!options.callback && !options.width) {
     options = { callback: options };
   }
   options = $.extend({


### PR DESCRIPTION
When 'callback' option was missing script was ignoring 'width' option.

This wont work:
```javascript
$.farbtastic("#color", {width: 250});
```

This will:
```javascript
$.farbtastic("#color", {callback: function(){}, width: 250});
```

Proposed fix will work for now but to avoid any future problems i think there should be something like:
```javascript
typeof callback === 'function'
```